### PR TITLE
feat: Implement Item Asset Loader

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -2,6 +2,7 @@
 GameDefaultMap=/Game/ThirdPerson/Maps/ThirdPersonMap.ThirdPersonMap
 EditorStartupMap=/Game/ThirdPerson/Maps/ThirdPersonMap.ThirdPersonMap
 GlobalDefaultGameMode="/Script/ItemRollDemo.ItemRollDemoGameMode"
+GameInstanceClass=/Script/ItemRollDemo.ItemGameInstance
 
 [/Script/Engine.RendererSettings]
 r.ReflectionMethod=1

--- a/ItemRollDemo.uproject
+++ b/ItemRollDemo.uproject
@@ -9,7 +9,8 @@
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
 			"AdditionalDependencies": [
-				"Engine"
+				"Engine",
+				"CoreUObject"
 			]
 		}
 	],

--- a/Source/ItemRollDemo/ItemAssetLoader.cpp
+++ b/Source/ItemRollDemo/ItemAssetLoader.cpp
@@ -1,0 +1,152 @@
+// Copyright Tony Sze 2024
+
+
+#include "ItemAssetLoader.h"
+#include "ItemsPrimaryDataAsset.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+
+void UItemAssetLoader::InitItemAssetLoader()
+{
+	TArray<FAssetData> AssetDataArray = LoadGameItemsAssetData();
+
+	InsertAssetsToMap(AssetDataArray);
+}
+
+const UItemsPrimaryDataAsset* UItemAssetLoader::GetRandomItem() const
+{
+	if (ItemsArray.Num() > 0)
+	{
+		int ChosenIndex = FMath::RandRange(0, ItemsArray.Num() - 1);
+
+		return ItemsArray[ChosenIndex];
+	}
+	else
+	{
+		return nullptr;
+	}
+}
+
+const UItemsPrimaryDataAsset* UItemAssetLoader::GetRandomItem(EItemRarity* ItemRarity, EItemType* ItemType) const
+{
+	TArray<EItemRarity> RarityArray;
+	TArray<EItemType> TypeArray;
+
+	if (ItemRarity)
+	{
+		RarityArray.Add(*ItemRarity);
+	}
+
+	if (ItemType)
+	{
+		TypeArray.Add(*ItemType);
+	}
+
+	TArray<UItemsPrimaryDataAsset*> ItemPool = GetItemsByRarityAndType(RarityArray, TypeArray);
+
+	if (ItemPool.Num() > 0)
+	{
+		int ChosenIndex = FMath::RandRange(0, ItemPool.Num() - 1);
+
+		return ItemPool[ChosenIndex];
+	}
+	else
+	{
+		return nullptr;
+	}
+}
+
+const TArray<UItemsPrimaryDataAsset*> UItemAssetLoader::GetItemsByRarity(TArray<EItemRarity>& ItemRarities) const
+{
+	TArray<EItemType> BlankTypes;
+	return GetItemsByRarityAndType(ItemRarities, BlankTypes);
+}
+
+const TArray<UItemsPrimaryDataAsset*> UItemAssetLoader::GetItemsByType(TArray<EItemType>& ItemTypes) const
+{
+	TArray<EItemRarity> BlankRarities;
+	return GetItemsByRarityAndType(BlankRarities, ItemTypes);
+}
+
+// Accepts blank ItemRarities and ItemTypes, when a specific filter as no entries, assume no filter.
+const TArray<UItemsPrimaryDataAsset*> UItemAssetLoader::GetItemsByRarityAndType(TArray<EItemRarity>& ItemRarities, TArray<EItemType>& ItemTypes) const
+{
+	TArray<UItemsPrimaryDataAsset*> CombinedItemsArray;
+	
+	CombinedItemsArray = ItemsArray;
+
+	CombinedItemsArray = CombinedItemsArray.FilterByPredicate([&ItemRarities, &ItemTypes](const UItemsPrimaryDataAsset* Item) {
+		bool bRarityMatch = false;
+		bool bTypeMatch = false;
+
+		if (ItemRarities.Num() > 0)
+		{
+			for (EItemRarity ItemRarity : ItemRarities)
+			{
+				if (Item->GetItemRarity() == ItemRarity)
+				{
+					bRarityMatch = true;
+				}
+			}
+		}
+		else
+		{
+			bRarityMatch = true;
+		}
+
+		if (ItemTypes.Num() > 0)
+		{
+			for (EItemType ItemType : ItemTypes)
+			{
+				if (Item->GetItemType() == ItemType)
+				{
+					bTypeMatch = true;
+				}
+			}
+		}
+		else
+		{
+			bTypeMatch = true;
+		}
+
+		return (bRarityMatch && bTypeMatch);
+	});
+
+	return CombinedItemsArray;
+}
+
+const TArray<UItemsPrimaryDataAsset*> UItemAssetLoader::GetAllItems() const
+{
+	return ItemsArray;
+}
+
+// Get all item assets from asset registry
+TArray<FAssetData> UItemAssetLoader::LoadGameItemsAssetData()
+{
+	FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+
+	TArray<FAssetData> AssetDataArray;
+	FARFilter Filter;
+
+	Filter.ClassPaths.Add(UItemsPrimaryDataAsset::StaticClass()->GetClassPathName());
+
+	AssetRegistryModule.Get().GetAssets(Filter, AssetDataArray);
+
+	return AssetDataArray;
+}
+
+void UItemAssetLoader::InsertAssetsToMap(TArray<FAssetData>& AssetDataArray)
+{
+	for (FAssetData AssetDataEntry : AssetDataArray)
+	{
+		UObject* ObjectToStore = AssetDataEntry.GetAsset();
+
+		UItemsPrimaryDataAsset* ItemDataAsset = Cast<UItemsPrimaryDataAsset>(ObjectToStore);
+
+		EItemRarity ItemRarity = ItemDataAsset->GetItemRarity();
+		EItemType ItemType = ItemDataAsset->GetItemType();
+
+		ItemsArray.Add(ItemDataAsset);
+	}
+}
+
+

--- a/Source/ItemRollDemo/ItemAssetLoader.h
+++ b/Source/ItemRollDemo/ItemAssetLoader.h
@@ -1,0 +1,43 @@
+// Copyright Tony Sze 2024
+
+#pragma once
+
+#include "ItemTypes.h"
+#include "ItemAssetLoader.generated.h"
+
+/**
+ * Class responsible for the loading and querying of game item assets
+ */
+
+class UItemsPrimaryDataAsset;
+
+UCLASS()
+class ITEMROLLDEMO_API UItemAssetLoader : public UObject
+{
+	GENERATED_BODY()
+	
+public:
+
+	void InitItemAssetLoader();
+
+	const UItemsPrimaryDataAsset* GetRandomItem() const;
+
+	const UItemsPrimaryDataAsset* GetRandomItem(EItemRarity* ItemRarity, EItemType* ItemType) const;
+
+private:
+
+	UPROPERTY()
+	TArray<UItemsPrimaryDataAsset*> ItemsArray;
+
+	TArray<FAssetData> LoadGameItemsAssetData();
+
+	void InsertAssetsToMap(TArray<FAssetData>& AssetDataArray);
+
+	const TArray<UItemsPrimaryDataAsset*> GetItemsByRarity(TArray<EItemRarity>& ItemRarities) const;
+
+	const TArray<UItemsPrimaryDataAsset*> GetItemsByType(TArray<EItemType>& ItemTypes) const;
+
+	const TArray<UItemsPrimaryDataAsset*> GetItemsByRarityAndType(TArray<EItemRarity>& ItemRarities, TArray<EItemType>& ItemTypes) const;
+
+	const TArray<UItemsPrimaryDataAsset*> GetAllItems() const;
+};

--- a/Source/ItemRollDemo/ItemGameInstance.cpp
+++ b/Source/ItemRollDemo/ItemGameInstance.cpp
@@ -1,0 +1,12 @@
+// Copyright Tony Sze 2024
+
+
+#include "ItemGameInstance.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+
+void UItemGameInstance::Init()
+{
+	ItemAssetLoader = NewObject<UItemAssetLoader>();
+
+	ItemAssetLoader->InitItemAssetLoader();
+}

--- a/Source/ItemRollDemo/ItemGameInstance.h
+++ b/Source/ItemRollDemo/ItemGameInstance.h
@@ -1,0 +1,27 @@
+// Copyright Tony Sze 2024
+
+#pragma once
+
+#include "Engine/GameInstance.h"
+#include "ItemAssetLoader.h"
+#include "ItemGameInstance.generated.h"
+
+class UItemsPrimaryDataAsset;
+
+/**
+ * 
+ */
+
+UCLASS()
+class ITEMROLLDEMO_API UItemGameInstance : public UGameInstance
+{
+	GENERATED_BODY()
+
+public:
+
+	virtual void Init() override;
+
+	UPROPERTY(BlueprintReadOnly)
+	UItemAssetLoader* ItemAssetLoader;
+
+};

--- a/Source/ItemRollDemo/ItemRarityDataAsset.h
+++ b/Source/ItemRollDemo/ItemRarityDataAsset.h
@@ -9,7 +9,7 @@
  * 
  */
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FItemRarityEntry
 {
 	GENERATED_BODY()

--- a/Source/ItemRollDemo/ItemsPrimaryDataAsset.cpp
+++ b/Source/ItemRollDemo/ItemsPrimaryDataAsset.cpp
@@ -7,3 +7,43 @@ FPrimaryAssetId UItemsPrimaryDataAsset::GetPrimaryAssetId() const
 {
 	return FPrimaryAssetId("Item", ItemName);
 }
+
+const EItemType UItemsPrimaryDataAsset::GetItemType() const
+{
+	return ItemType;
+}
+
+const FName UItemsPrimaryDataAsset::GetItemName() const
+{
+	return ItemName;
+}
+
+const FString UItemsPrimaryDataAsset::GetItemDescription() const
+{
+	return ItemDescription;
+}
+
+const UTexture2D* UItemsPrimaryDataAsset::GetItemImage() const
+{
+	return ItemImage;
+}
+
+const UStaticMesh* UItemsPrimaryDataAsset::GetItemStaticMesh() const
+{
+	return ItemStaticMesh;
+}
+
+const EItemRarity UItemsPrimaryDataAsset::GetItemRarity() const
+{
+	return ItemRarity;
+}
+
+const TArray<FItemRangeEntry> UItemsPrimaryDataAsset::GetItemAllowedEffects() const
+{
+	return AllowedItemEffects;
+}
+
+const int UItemsPrimaryDataAsset::GetItemAllowedEffectsCount() const
+{
+	return AllowedEffectsCount;
+}

--- a/Source/ItemRollDemo/ItemsPrimaryDataAsset.h
+++ b/Source/ItemRollDemo/ItemsPrimaryDataAsset.h
@@ -11,7 +11,7 @@
  * 
  */
 
-USTRUCT()
+USTRUCT(BlueprintType)
 struct FItemRangeEntry
 {
 	GENERATED_BODY()
@@ -30,6 +30,33 @@ UCLASS()
 class ITEMROLLDEMO_API UItemsPrimaryDataAsset : public UPrimaryDataAsset
 {
 	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable)
+	const EItemType GetItemType() const;
+
+	UFUNCTION(BlueprintCallable)
+	const FName GetItemName() const;
+
+	UFUNCTION(BlueprintCallable)
+	const FString GetItemDescription() const;
+
+	UFUNCTION(BlueprintCallable)
+	const UTexture2D* GetItemImage() const;
+
+	UFUNCTION(BlueprintCallable)
+	const UStaticMesh* GetItemStaticMesh() const;
+
+	UFUNCTION(BlueprintCallable)
+	const EItemRarity GetItemRarity() const;
+
+	UFUNCTION(BlueprintCallable)
+	const TArray<FItemRangeEntry> GetItemAllowedEffects() const;
+
+	UFUNCTION(BlueprintCallable)
+	const int GetItemAllowedEffectsCount() const;
+
+private:
 
 	// The type of item (slot) this is
 	UPROPERTY(EditAnywhere)


### PR DESCRIPTION
- Add custom GameInstance class to facilitate loading assets on Init()
- Add ItemAssetLoader class, responsible for loading item assets from Asset Registry to TMap, as well as generate a random item based on item rarity and item type filter(s).
- Modify ItemsPrimaryDataAsset and ItemRarityDataAsset structs to be BlueprintType to enable use.