### PR TITLE
fix: change getters to return non const in ItemsPrimaryDataAsset

### DIFF
--- a/Source/ItemRollDemo/ItemsPrimaryDataAsset.h
+++ b/Source/ItemRollDemo/ItemsPrimaryDataAsset.h
@@ -33,28 +33,28 @@ class ITEMROLLDEMO_API UItemsPrimaryDataAsset : public UPrimaryDataAsset
 
 public:
 	UFUNCTION(BlueprintCallable)
-	const EItemType GetItemType() const;
+	EItemType GetItemType() const;
 
 	UFUNCTION(BlueprintCallable)
-	const FName GetItemName() const;
+	FName GetItemName() const;
 
 	UFUNCTION(BlueprintCallable)
-	const FString GetItemDescription() const;
+	FString GetItemDescription() const;
 
 	UFUNCTION(BlueprintCallable)
-	const UTexture2D* GetItemImage() const;
+	UTexture2D* GetItemImage() const;
 
 	UFUNCTION(BlueprintCallable)
-	const UStaticMesh* GetItemStaticMesh() const;
+	UStaticMesh* GetItemStaticMesh() const;
 
 	UFUNCTION(BlueprintCallable)
-	const EItemRarity GetItemRarity() const;
+	EItemRarity GetItemRarity() const;
 
 	UFUNCTION(BlueprintCallable)
-	const TArray<FItemRangeEntry> GetItemAllowedEffects() const;
+	TArray<FItemRangeEntry> GetItemAllowedEffects() const;
 
 	UFUNCTION(BlueprintCallable)
-	const int GetItemAllowedEffectsCount() const;
+	int GetItemAllowedEffectsCount() const;
 
 private:
 


### PR DESCRIPTION
- Change all getters in ItemsPrimaryDataAsset to be non-const return values.  The non-pointer UObjects would be a copy anyway, and the pointer return values (GetItemImage() and GetItemStaticMesh() needs to be non const to be used properly in other classes.