### PR TITLE
fix: Add null check for ItemSpawnerButton

### DIFF
--- a/Content/Map/DemoWorld.umap
+++ b/Content/Map/DemoWorld.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6da6f2b973e718a423dbbcc7daf48feb9e6830161e1ede6debca282d5fd25c4
-size 40048
+oid sha256:5e59f24aa191e5dfe24d1cf5c2a836c0c0fe3d145d4bbb325565dc6552b5cae3
+size 40039

--- a/Source/ItemRollDemo/ItemSpawnerButton.cpp
+++ b/Source/ItemRollDemo/ItemSpawnerButton.cpp
@@ -21,7 +21,10 @@ void AItemSpawnerButton::BroadcastSpawn()
 {
 	for (AItemSpawnerPlatform* Platform : ControlledPlatforms)
 	{
-		Platform->SpawnNewItem();
+		if (Platform)
+		{
+			Platform->SpawnNewItem();
+		}
 	}
 }
 


### PR DESCRIPTION
- Add null check for ItemSpawnerButton when user presses the button to prevent crash on null platform entries.